### PR TITLE
fix: memleak

### DIFF
--- a/compute/compute.go
+++ b/compute/compute.go
@@ -6,9 +6,7 @@ import (
 	"go/token"
 	"strconv"
 	"strings"
-)
 
-import (
 	"github.com/skOak/calc/constants"
 	"github.com/skOak/calc/operators"
 	"github.com/skOak/calc/operators/functions"
@@ -26,6 +24,7 @@ func Evaluate(in string, source variables.ValueSource) (float64, error) {
 	floats := NewFloatStack()
 	ops := NewStringStack()
 	s := initScanner(in)
+	defer ClearHistory()
 
 	var prev token.Token = token.ILLEGAL
 	var back int = -1

--- a/compute/mem_test.go
+++ b/compute/mem_test.go
@@ -1,0 +1,50 @@
+package compute
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/skOak/calc/variables"
+)
+
+type mockSource struct {
+	props []string
+	val   float64
+}
+
+func mockValueSourceFunc(v string) float64 {
+	m := &mockSource{
+		props: make([]string, 1000*1000),
+		val:   1.1,
+	}
+	return m.val
+}
+
+const DELTA = 0.000001
+
+func TestCompute(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		for expression, expected := range exps {
+			v, err := Evaluate(expression, variables.ValueSourceFunc(mockValueSourceFunc))
+			if err != nil || math.Abs(v-expected) > DELTA {
+				t.Fatal(fmt.Sprintf("calc err, expected: %v, v: %v", expected, v))
+			}
+		}
+	}
+}
+
+var exps = map[string]float64{
+	"1+__a+__b+__c": 4.3,
+}
+
+func BenchmarkEvaluate(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for expression, expected := range exps {
+			v, err := Evaluate(expression, variables.ValueSourceFunc(mockValueSourceFunc))
+			if err != nil || math.Abs(v-expected) > DELTA {
+				panic(fmt.Sprintf("calc err, expected: %v, v: %v", expected, v))
+			}
+		}
+	}
+}


### PR DESCRIPTION

- before  


```
(pprof) top10 -cum
Showing nodes accounting for 76.71GB, 100% of 76.74GB total
Dropped 12 nodes (cum <= 0.38GB)
      flat  flat%   sum%        cum   cum%
         0     0%     0%    76.74GB   100%  github.com/skOak/calc/compute.BenchmarkEvaluate
         0     0%     0%    76.74GB   100%  github.com/skOak/calc/compute.Evaluate
         0     0%     0%    76.74GB   100%  testing.(*B).launch
         0     0%     0%    76.74GB   100%  testing.(*B).runN
   76.71GB   100%   100%    76.71GB   100%  github.com/skOak/calc/compute.pushHistory (inline)
```

- with `defer CleanHistory()`

```
Type: alloc_space
Time: May 7, 2021 at 8:39pm (CST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10 -cum
Showing nodes accounting for 11.49GB, 100% of 11.49GB total
Dropped 3 nodes (cum <= 0.06GB)
      flat  flat%   sum%        cum   cum%
         0     0%     0%    11.49GB   100%  github.com/skOak/calc/compute.BenchmarkEvaluate
         0     0%     0%    11.49GB   100%  github.com/skOak/calc/compute.Evaluate
         0     0%     0%    11.49GB   100%  testing.(*B).runN
   11.49GB   100%   100%    11.49GB   100%  github.com/skOak/calc/compute.mockValueSourceFunc
         0     0%   100%    11.49GB   100%  github.com/skOak/calc/variables.GetValue
         0     0%   100%    11.49GB   100%  github.com/skOak/calc/variables.ValueSourceFunc.GetValue
         0     0%   100%    11.45GB 99.61%  testing.(*B).launch
```